### PR TITLE
Add Alpine Autosize Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ To contribute, fork this repository, add your new resource and submit a PR. For 
 * [Alpine Wizard - Build multi-step wizards with Alpine.js](https://github.com/glhd/alpine-wizard)
 * [Alpine $fetch - A magic helper to integrate HTTP fetch requests directly within Alpine.js markup](https://github.com/hankhank10/alpine-fetch)
 * [alpinejs-router - Easy to use and flexible router for Alpine.js, support dynamic route matching with params](https://github.com/shaunlee/alpinejs-router)
+* [Alpine Autosize - Directive for autosizing textareas](https://github.com/marcreichel/alpine-autosize)
 
 ## Other
 


### PR DESCRIPTION
[Alpine Autosize](https://github.com/marcreichel/alpine-autosize) is a small Alpine plugin that provides a `x-autosize` directive.

Adding it to a `<textarea>` the textarea resizes automatically fitting its content.