### PR TITLE
Add Alpine Timago Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ To contribute, fork this repository, add your new resource and submit a PR. For 
 * [Alpine Wizard - Build multi-step wizards with Alpine.js](https://github.com/glhd/alpine-wizard)
 * [Alpine $fetch - A magic helper to integrate HTTP fetch requests directly within Alpine.js markup](https://github.com/hankhank10/alpine-fetch)
 * [alpinejs-router - Easy to use and flexible router for Alpine.js, support dynamic route matching with params](https://github.com/shaunlee/alpinejs-router)
+* [Alpine Timeago - Display the human-readable distance between a date and now](https://github.com/marcreichel/alpine-timeago)
 
 ## Other
 


### PR DESCRIPTION
[Alpine Timago](https://github.com/marcreichel/alpine-timeago) is a small plugin that provides a `x-timeago` directive and `$timeago` magic helper that prints out the human-readable distance between a specific date and now. Like `2 weeks ago` for example.