### PR TITLE
Add alpine-editable

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ To contribute, fork this repository, add your new resource and submit a PR. For 
 * [Alpine Typewrite - Add a typewriter animation to any HTML element](https://github.com/marcreichel/alpine-typewriter)
 * [Alpine AJAX - Tools to build AJAX-powered components and UI](https://github.com/imacrayon/alpine-ajax)
 * [Norska - Create interactive Three.js scenes directly with Alpine](https://github.com/Plumie/Norska)
+* [alpine-editable - Alpine integration for editable.js, the friendly contenteditable API](https://github.com/mgschoen/alpine-editable)
 
 ## UI Frameworks
 


### PR DESCRIPTION
`alpine-editable` is a plugin that simplifies using [`contenteditable`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/contenteditable) with Alpine JS. It uses the [`editable.js`](https://github.com/livingdocsIO/editable.js) library under the hood.

The plugin provides the `x-editable` directive for making an element editable and forwards `editable.js` events to the DOM, making them accessible to Alpine's `x-on`.